### PR TITLE
fix(docs): changed link to ssn description in sensitive data guide

### DIFF
--- a/docs/sensitive-data-analysis.md
+++ b/docs/sensitive-data-analysis.md
@@ -3,6 +3,7 @@
 ## SSN (Social Security Number)
 
 **Documents**:
+
 - [https://www.investopedia.com/terms/s/ssn.asp](https://www.investopedia.com/terms/s/ssn.asp)
 - [https://en.wikipedia.org/wiki/Social_Security_number](https://en.wikipedia.org/wiki/Social_Security_number)
 
@@ -11,24 +12,27 @@ Three number fields are separated by dashes.
 **Format**: `AAA-GG-SSSS`
 
 where:
-- `AAA` - Area number. Excludes `000`. Values 650-699 unassigned.
-Values 700-728 for railroad workers through 1963 (discontinued).
-Values 729-799 unassigned.
-Values 800-999 invalid.
-Since June 25, 2011, SSA assigns randomly, including 734-749 and above 772 through 800s.
+
+- `AAA` - Area number. Excludes `000`. Values 650-699 unassigned. Values 700-728
+  for railroad workers through 1963 (discontinued). Values 729-799 unassigned.
+  Values 800-999 invalid. Since June 25, 2011, SSA assigns randomly, including
+  734-749 and above 772 through 800s.
 - `GG` - Group number. Excludes `00`.
 - `SSSS` - Serial number. Excludes `0000`.
 
-Numbers cannot start or end with a letter, dash-number, or dash-letter from left/right sides.
+Numbers cannot start or end with a letter, dash-number, or dash-letter from
+left/right sides.
 
 ## ICCID (Integrated Circuit Card Identifier)
 
 **Document**:
+
 - [https://www.theiphonewiki.com/wiki/ICCID](https://www.theiphonewiki.com/wiki/ICCID)
 
 **Format**: `MMCC IINN NNNN NNNN NN C x`, 19-20 digits
 
 where:
+
 - `MM` - Constant `89` for telecom operators.
 - `CC` - Country code (e.g., 61=Australia, 86=China), 1-3 digits.
 - `II` - Issuer identifier, 1-4 digits.
@@ -38,9 +42,11 @@ where:
 ## PN (Password Number)
 
 **Document**:
+
 - Country-dependent.
 
 **Formats**:
+
 - US: 9 digits.
-- UK: 9 digits.  
+- UK: 9 digits.
 - Japan: 2 Latin letters + 7 digits.

--- a/docs/sensitive-data-analysis.md
+++ b/docs/sensitive-data-analysis.md
@@ -1,38 +1,42 @@
-# The sensitive data description
-## 1. SSN (Social Security Number)
+# Sensitive Data Descriptions
 
-**Document**:
-* [https://www.investopedia.com/terms/s/ssn.asp](https://www.investopedia.com/terms/s/ssn.asp)
-* [https://en.wikipedia.org/wiki/Social_Security_number](https://en.wikipedia.org/wiki/Social_Security_number)  
-Three number fields are separated by dash
+## SSN (Social Security Number)
+
+**Documents**:
+- [https://www.investopedia.com/terms/s/ssn.asp](https://www.investopedia.com/terms/s/ssn.asp)
+- [https://en.wikipedia.org/wiki/Social_Security_number](https://en.wikipedia.org/wiki/Social_Security_number)
+
+Three number fields are separated by dashes.
+
 **Format**: `AAA-GG-SSSS`
-where:
-* `AAA` - is area number. The value `000` is excluded by default.
-Values 650-699 is not assigned.
-Values 700-728 is Railroad workers through 1963, then discontinued.
-Values 729-799 is not assigned.
-Values 800-999 is not valid.
-Effective June 25, 2011, the SSA assigns SSNs randomly and allows for the assignment of area numbers between 734 and 749 and above 772 through the 800s.  
-* `GG` - is group number. The value 00 is excluded by default.
-* `SSSS` - is serial number. The value 0000 is excluded by default.
-From left/right side the number, letter or dash with number or letter cannot be.
 
-## 2. ICCID (Integrated Circuit Card Identifier)
+where:
+- `AAA` - Area number. Excludes `000`. Values 650-699 unassigned. Values 700-728 for railroad workers through 1963 (discontinued). Values 729-799 unassigned. Values 800-999 invalid. Since June 25, 2011, SSA assigns randomly, including 734-749 and above 772 through 800s.
+- `GG` - Group number. Excludes `00`.
+- `SSSS` - Serial number. Excludes `0000`.
+
+Numbers cannot start or end with a letter, dash-number, or dash-letter from left/right sides.
+
+## ICCID (Integrated Circuit Card Identifier)
 
 **Document**:
-* [https://www.theiphonewiki.com/wiki/ICCID](https://www.theiphonewiki.com/wiki/ICCID)
-**Format**: `MMCC IINN NNNN NNNN NN C x`, Length 19-20 digits
+- [https://www.theiphonewiki.com/wiki/ICCID](https://www.theiphonewiki.com/wiki/ICCID)
+
+**Format**: `MMCC IINN NNNN NNNN NN C x`, 19-20 digits
+
 where:
-* `MM` - Constant, 89 for telecom operators.
-* `CC` - Country code (i.e. 61 = Australia, 86 = China). Length 1-3
-* `II` - Issuer identifier. Length 1-4
-* `N`{11-12} - Account ID (SIM number).
-* `C` - Checksum calculated from the other 19 digits using the Luhn algorithm.
-## 3. PN (Password Number)
+- `MM` - Constant `89` for telecom operators.
+- `CC` - Country code (e.g., 61=Australia, 86=China), 1-3 digits.
+- `II` - Issuer identifier, 1-4 digits.
+- `N`{11-12} - Account ID (SIM number).
+- `C` - Checksum via Luhn algorithm on prior 19 digits.
+
+## PN (Password Number)
 
 **Document**:
-* Depend on country
-**Format**:  
-US: 9 digits  
-British: 9 digits  
-Japan: 2 latin alpha, 7 digits  
+- Country-dependent.
+
+**Formats**:
+- US: 9 digits.
+- UK: 9 digits.  
+- Japan: 2 Latin letters + 7 digits.

--- a/docs/sensitive-data-analysis.md
+++ b/docs/sensitive-data-analysis.md
@@ -11,7 +11,11 @@ Three number fields are separated by dashes.
 **Format**: `AAA-GG-SSSS`
 
 where:
-- `AAA` - Area number. Excludes `000`. Values 650-699 unassigned. Values 700-728 for railroad workers through 1963 (discontinued). Values 729-799 unassigned. Values 800-999 invalid. Since June 25, 2011, SSA assigns randomly, including 734-749 and above 772 through 800s.
+- `AAA` - Area number. Excludes `000`. Values 650-699 unassigned.
+Values 700-728 for railroad workers through 1963 (discontinued).
+Values 729-799 unassigned.
+Values 800-999 invalid.
+Since June 25, 2011, SSA assigns randomly, including 734-749 and above 772 through 800s.
 - `GG` - Group number. Excludes `00`.
 - `SSSS` - Serial number. Excludes `0000`.
 

--- a/docs/sensitive-data-analysis.md
+++ b/docs/sensitive-data-analysis.md
@@ -1,36 +1,37 @@
 # The sensitive data description
 ## 1. SSN (Social Security Number)
-**Document**:
-    - [https://www.usrecordsearch.com/ssn.htm](https://www.usrecordsearch.com/ssn.htm)
-    - [https://en.wikipedia.org/wiki/Social_Security_number](https://en.wikipedia.org/wiki/Social_Security_number)  
-Three number fields are separated by dash
 
+**Document**:
+* [https://www.investopedia.com/terms/s/ssn.asp](https://www.investopedia.com/terms/s/ssn.asp)
+* [https://en.wikipedia.org/wiki/Social_Security_number](https://en.wikipedia.org/wiki/Social_Security_number)  
+Three number fields are separated by dash
 **Format**: `AAA-GG-SSSS`
 where:
 * `AAA` - is area number. The value `000` is excluded by default.
-    Values 650-699 is not assigned.
-    Values 700-728 is Railroad workers through 1963, then discontinued.
-    Values 729-799 is not assigned.
-    Values 800-999 is not valid.
-    Effective June 25, 2011, the SSA assigns SSNs randomly and allows for the assignment of area numbers between 734 and 749 and above 772 through the 800s.  
+Values 650-699 is not assigned.
+Values 700-728 is Railroad workers through 1963, then discontinued.
+Values 729-799 is not assigned.
+Values 800-999 is not valid.
+Effective June 25, 2011, the SSA assigns SSNs randomly and allows for the assignment of area numbers between 734 and 749 and above 772 through the 800s.  
 * `GG` - is group number. The value 00 is excluded by default.
 * `SSSS` - is serial number. The value 0000 is excluded by default.
 From left/right side the number, letter or dash with number or letter cannot be.
+
 ## 2. ICCID (Integrated Circuit Card Identifier)
+
 **Document**:
 * [https://www.theiphonewiki.com/wiki/ICCID](https://www.theiphonewiki.com/wiki/ICCID)
-
 **Format**: `MMCC IINN NNNN NNNN NN C x`, Length 19-20 digits
 where:
 * `MM` - Constant, 89 for telecom operators.
 * `CC` - Country code (i.e. 61 = Australia, 86 = China). Length 1-3
 * `II` - Issuer identifier. Length 1-4
-* `N`{11-12} - Account id (SIM number).
+* `N`{11-12} - Account ID (SIM number).
 * `C` - Checksum calculated from the other 19 digits using the Luhn algorithm.
 ## 3. PN (Password Number)
+
 **Document**:
 * Depend on country
-
 **Format**:  
 US: 9 digits  
 British: 9 digits  


### PR DESCRIPTION
Changed link in docs for ssn description to https://www.investopedia.com/terms/s/ssn.asp